### PR TITLE
fix: buffer overread vulnerability in strncpy

### DIFF
--- a/boot/common/lib/string.c
+++ b/boot/common/lib/string.c
@@ -154,7 +154,7 @@ char *strncpy(char *dest, const char *src, size_t n)
 
 	char *pdest = dest;
 
-	while (*src != '\0' || n--) {
+	while (*src != '\0' && n--) {
 		*pdest++ = *src++;
 	}
 


### PR DESCRIPTION
# This PR fixes a critical buffer overread vulnerability in the `strncpy` implementation.

## Description
The `strncpy` function in `boot/common/lib/string.c` contained a logic error on line 157 where the OR operator (`||`) was used instead of the AND operator (`&&`) in the loop condition.

### The Bug
```c
// BEFORE (vulnerable):
while (*src != '\0' || n--)
```

With the OR operator, the loop continues reading from src even after reaching the null terminator, as long as n > 0. This causes the function to read beyond the source buffer bounds into undefined memory.

The Fix
```c
// AFTER (secure):
while (*src != '\0' && n--)
```
The AND operator ensures the loop terminates when either the null terminator is reached or n characters have been copied, preventing buffer overread.