### PR TITLE
fix: buffer overflow in strncpy and mem_realloc

### DIFF
--- a/boot/common/lib/string.c
+++ b/boot/common/lib/string.c
@@ -148,16 +148,20 @@ char *strcpy(char *dest, const char *src)
 
 char *strncpy(char *dest, const char *src, size_t n)
 {
-	if (dest == NULL || src == NULL) {
+	if (dest == NULL || src == NULL || n == 0) {
 		return NULL;
 	}
 
 	char *pdest = dest;
+	size_t i = 0;
 
-	while (*src != '\0' && n--) {
+	// Copy at most n-1 characters to leave room for null terminator
+	while (*src != '\0' && i < n - 1) {
 		*pdest++ = *src++;
+		i++;
 	}
 
+	// Always null-terminate within bounds
 	*pdest = '\0';
 	return dest;
 }

--- a/boot/common/mm/mman.c
+++ b/boot/common/mm/mman.c
@@ -154,7 +154,9 @@ void *mem_realloc(void *addr, size_t n)
 		return NULL;
 	}
 
-	memcpy(new, addr, old_size);
+	// Only copy the minimum of old_size and new size to prevent overflow
+	size_t copy_size = (old_size < n) ? old_size : n;
+	memcpy(new, addr, copy_size);
 	mem_free(addr);
 	return new;
 }


### PR DESCRIPTION
1. strncpy Buffer Overflow

Issue: Wrote null terminator at dest[n] causing 1-byte overflow
Fix: Now copies at most n-1 characters and always null-terminates within bounds

2. mem_realloc Buffer Overflow

Issue: Copied old_size bytes even when reallocating to smaller buffer
Fix: Now copies min(old_size, n) to prevent overflow when shrinking allocations